### PR TITLE
Takeda fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # メルカリ クローン DB設計
-## userテーブル
+## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
 |nickname|string|null: false|
@@ -9,17 +9,18 @@
 |first_name_kana|string|null :false|
 |email|string|null: false|
 |password|string|null: false|
-|birthday|integer|null: false|
+|birthday|date|null: false|
 |phone_number|string|unique:true|
 |profile|string|
 
 ### Association
 - has_many :products
+- has_many ::sns_credentials, :dependent => :destroy
 - has_many :comments, :dependent => :destroy
 - has_one :user_address
 - has_one :card_info
 
-## user_addressテーブル
+## user_addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null :false|
@@ -27,22 +28,34 @@
 |prefectures|integer|null :false|
 |city|string|null :false|
 |address|string|null :false|
-|building|string|null :false|
+|building|string|
 
 ### Association
-- belongs_to :user
+- belongs_to :user, optional: true
 
-## card_infoテーブル
+## sns_credentials
 |Column|Type|Options|
 |------|----|-------|
-|user_id|reference|null :false|
-|card_number|integer|null: false|
-|use_limit|integer|null: false|
-|security_code|integer|null: false|
+|provider|string|
+|uid|string|
+|user_id|bigint|
 
 ### Association
 - belongs_to :user
 
+## card_infosテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null :false|
+|card_number|bigint|
+|security_code|integer|
+|use_limit_month|integer|
+|use_limit_year|integer|
+|customer_id|string|null :false|
+|card_id|string|null :false|
+
+### Association
+- belongs_to :user,optional: true
 
 ## productsテーブル
 |Column|Type|Options|
@@ -58,21 +71,26 @@
 |shipping_method|string|
 |delivery_area|string|null :false|
 |user_id|integer|null: false, foreign_key: true|
+|estimated_delivery|string|
+|image|string|
+|status|integer|
+|buyer_id|integer|
 
 ### Association
 - belongs_to :user
 - belongs_to :category
+- belongs_to :brand
 - has_many :photos, :dependent => :destroy
 - has_many :comments, :dependent => :destroy
 
 ## photosテーブル
 |Column|Type|Options|
 |------|----|-------|
-|product_id|reference|null :false, foreign_key: true|
-|name|string|
+|product_id|bigint|null :false, foreign_key: true|
+|image_url|string|
 
 ### Association
-- belongs_to :product
+- belongs_to :product,optional: true, :dependent => :destroy
 
 ## commentsテーブル
 |Column|Type|Options|
@@ -84,7 +102,7 @@
 - belongs_to :user
 - belongs_to :product
 
-## categoryテーブル
+## categoriesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
@@ -95,17 +113,36 @@ has_many :blands
 has_many :products
 has_one :category_size
 
-## category_sizeテーブル
+## category_sizesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |size_id|integer|null: false|
 |size|string|
 
-
-### blandテーブル
+### brandテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|
 
 ### Association
 - has_many :products
+
+## shipping_methodsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|shipping_method|string|
+
+## shipping_chargesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|shipping_charge|string|
+
+## delivery_areasテーブル
+|Column|Type|Options|
+|------|----|-------|
+|delivery_method|string|
+
+## conditionsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|condition|string|

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
 ### Association
 - belongs_to :product,optional: true, :dependent => :destroy
 
-## commentsテーブル
+## commentsテーブル(現在未実装)
 |Column|Type|Options|
 |------|----|-------|
 |text|text|null: false|

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -7,3 +7,4 @@ $mail: #EEEEEE;
 $facebook: #385185;
 $link-blue: #0099E8;
 $submit-red: #EA352D;
+$transmission: rgba(255, 255, 255, 0);

--- a/app/assets/stylesheets/modules/body.scss
+++ b/app/assets/stylesheets/modules/body.scss
@@ -57,6 +57,26 @@
 
             }
 
+            &__soldout{
+              display: block;
+              position: absolute;
+              border-top: 50px solid $submit-red;
+              border-left: 50px solid $submit-red;
+              border-right: 50px solid transparent;
+              border-bottom: 50px solid transparent;
+              
+              &__text{
+                position: absolute;
+                top: -35px;
+                left: -55px;
+                font-size: 24px;
+                font-weight: bold;
+                transform:rotate(-45deg);
+                color: $white;
+                background-color: $transmission; 
+              }
+            }
+
           }
           &__text{
             height: 40px;

--- a/app/assets/stylesheets/modules/exhibit.scss
+++ b/app/assets/stylesheets/modules/exhibit.scss
@@ -10,6 +10,17 @@
   right: 40px;
   bottom: 40px;
   text-decoration: none;
+  &__link{
+    display: block;
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    background-color: $transmission;
+    position: fixed;
+    right: 40px;
+    bottom: 40px;
+    z-index: 100;
+  }
   p{
     color: #FFF;
     margin-top: 32px;

--- a/app/assets/stylesheets/modules/products.scss
+++ b/app/assets/stylesheets/modules/products.scss
@@ -24,13 +24,30 @@
         background-color: #eee;
 
         &__view{
-
+          position: relative;
           &__image{
             height: 300px;
             width: 300px;
-            position: relative;
           }
-
+          &__soldout{
+            display: block;
+            position: absolute;
+            border-top: 60px solid $submit-red;
+            border-left: 60px solid $submit-red;
+            border-right: 60px solid transparent;
+            border-bottom: 60px solid transparent;
+            
+            &__text{
+              position: absolute;
+              top: -40px;
+              left: -58px;
+              font-size: 24px;
+              font-weight: bold;
+              transform:rotate(-45deg);
+              color: $white;
+              background-color: $transmission; 
+            }
+          }
         }
         &__select{
           display: flex;

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,8 +1,5 @@
 class Brand < ApplicationRecord
 
-  has_many :product
-
-
   has_many :products
 
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,3 @@
 class Category < ApplicationRecord
-  has_many :product
+  has_many :products
 end

--- a/app/views/products/layouts/_brand.html.haml
+++ b/app/views/products/layouts/_brand.html.haml
@@ -14,7 +14,13 @@
             .body__contents__view__product__box__image
               - @photos.each do |photo|
                 - if brand.id == photo.product_id
-                  = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),brand
+                  - if brand.status == 1
+                    .body__contents__view__product__box__image__soldout
+                      %p.body__contents__view__product__box__image__soldout__text
+                        SOLD
+                    = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),brand
+                  - else
+                    = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),brand
                   - break
             .body__contents__view__product__box__text
               = brand.name

--- a/app/views/products/layouts/_category.html.haml
+++ b/app/views/products/layouts/_category.html.haml
@@ -14,11 +14,15 @@
             .body__contents__view__product__box__image
               - @photos.each do |photo|
                 - if category.id == photo.product_id
-                  = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),category
-                  - break
-                  
+                  - if category.status == 1
+                    .body__contents__view__product__box__image__soldout
+                      %p.body__contents__view__product__box__image__soldout__text
+                        SOLD
+                    = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),category
+                  - else
+                    = link_to image_tag(photo.image_url, class: "body__contents__view__product__box__image__image-content"),category
+                - break
             .body__contents__view__product__box__text
               = category.name
             .body__contents__view__product__box__value
               = "¥#{category.price.to_s(:delimited, delimiter: ',')}"
-

--- a/app/views/products/layouts/_photo.html.haml
+++ b/app/views/products/layouts/_photo.html.haml
@@ -1,5 +1,11 @@
 .product-show-body__buy__top__photo
   .product-show-body__buy__top__photo__view
+  - if @product.status == 1
+    .product-show-body__buy__top__photo__view__soldout
+      %p.product-show-body__buy__top__photo__view__soldout__text
+        SOLD
+    = image_tag (@photos.first.image_url), class: "product-show-body__buy__top__photo__view__image"
+  - else
     = image_tag (@photos.first.image_url), class: "product-show-body__buy__top__photo__view__image"
   .product-show-body__buy__top__photo__select
     - @photos.each do |photo|

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,8 +1,8 @@
 .sell-container
   .sell-header
     %h1
-      = link_to "", "https://www.mercari.com/jp/"
-      = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3609274330",width:'185', height:'49'
+      = link_to root_path do
+        = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3609274330",width:'185', height:'49'
   .sell-body
     
     = form_with model: @product, local: true do |f|

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -18,8 +18,12 @@
         売り切れました
     - else
       .product-show-body__buy__btn
-        = link_to card_info_path(params[:id]), method: :get, class: "product-show-body__buy__btn__link" do
-          購入画面に進む
+        - if user_signed_in?
+          = link_to card_info_path(params[:id]), method: :get, class: "product-show-body__buy__btn__link" do
+            購入画面に進む
+        - else
+          = link_to new_user_session_path, method: :get, class: "product-show-body__buy__btn__link" do
+            購入画面に進む
     .product-show-body__buy__description
       = @product.text
     .product-show-body__buy__comment

--- a/app/views/shared/_exhibit.html.haml
+++ b/app/views/shared/_exhibit.html.haml
@@ -1,4 +1,4 @@
-= link_to new_product_path do
+= link_to new_product_path, class: "exhibit__link" do
   %p
     %a 出品
   .exhibit__camera

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -3,8 +3,8 @@
   .header-inner
     .header-inner-top
       %h1
-        = link_to "", "https://www.mercari.com/jp/"
-        = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3609274330",width: "134"
+        = link_to root_path do
+          = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?3609274330",width: "134"
 
       = form_tag('/search', method: :get, class: 'search-form') do
         %input.search-form__input{ placeholder: "何かお探しですか？"}

--- a/app/views/signup/_common-footer.html.haml
+++ b/app/views/signup/_common-footer.html.haml
@@ -9,6 +9,6 @@
         特定商取引に関する表記
     .common-footer__box__logo
       .common-footer__box__logo__mark
-        = link_to "#", class: "btn btn-gray-logo common-footer__box__logo__mark" do
+        = link_to root_path, class: "btn btn-gray-logo common-footer__box__logo__mark" do
           = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?2356214421", class: "signup-footer__box_logo__mark"
       %p.common-footer__box__logo__company © Mercari, Inc.

--- a/app/views/signup/_common-header.html.haml
+++ b/app/views/signup/_common-header.html.haml
@@ -1,4 +1,4 @@
 .common-header
   .common-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"

--- a/app/views/signup/_signup-header-finish.html.haml
+++ b/app/views/signup/_signup-header-finish.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/app/views/signup/_signup-header-step1.html.haml
+++ b/app/views/signup/_signup-header-step1.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/app/views/signup/_signup-header-step2.html.haml
+++ b/app/views/signup/_signup-header-step2.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/app/views/signup/_signup-header-step3.html.haml
+++ b/app/views/signup/_signup-header-step3.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/app/views/signup/_signup-header-step4.html.haml
+++ b/app/views/signup/_signup-header-step4.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/app/views/signup/_social-login.html.haml
+++ b/app/views/signup/_social-login.html.haml
@@ -1,6 +1,6 @@
 .signup-header
   .signup-header__logo
-    = link_to "#" do
+    = link_to root_path do
       = image_tag src="https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?4236546443"
   %nav.progress
     %ol.progress__all

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,16 +3,19 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
-    aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
-    region: 'ap-northeast-1'
+  if Rails.env.production?
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'freemarket-sample-58b'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket-sample-58b'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
+      aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+      region: 'ap-northeast-1'
   }
-
-
-  config.fog_directory  = 'freemarket-sample-58b'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket-sample-58b'
+  else
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
 end

--- a/config/initializers/twilio.rb
+++ b/config/initializers/twilio.rb
@@ -1,6 +1,8 @@
 
 require 'twilio-ruby'
 Twilio.configure do |config|
-  config.account_sid = Rails.application.credentials.twilio[:TWILIO_ACCOUNT_SID]
-  config.auth_token = Rails.application.credentials.twilio[:TWILIO_AUTH_TOKEN]
+  if Rails.env.production?
+    config.account_sid = Rails.application.credentials.twilio[:TWILIO_ACCOUNT_SID]
+    config.auth_token = Rails.application.credentials.twilio[:TWILIO_AUTH_TOKEN]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,14 +26,11 @@ Rails.application.routes.draw do
       get 'finish' #登録完了ページ
     end
   end
-  
-  resources :products, only: [:index, :show, :create, :new]
-  resources :products
-  post 'products/new' => 'products#new'
 
   resources :products, only: [:index, :new, :create, :update, :show, :destroy] do
     member do
       get 'details'
+      post 'products/new' => 'products#new'
     end
   end
 
@@ -42,8 +39,6 @@ Rails.application.routes.draw do
       get 'identification'
     end
   end
-
-  resources :users, only: [:index, :new, :show, :edit]
 
   root to: 'products#index'
   resources :category, only: [:category_list]


### PR DESCRIPTION
# WHAT
・READMEを最新版に修正
・デプロイとSMS認証に必要な記述の修正
　→これで毎回コメントアウトしてもらう必要はなくなったかと
・ルートで被っている部分の削除
・ロゴをクリックするとトップページに戻るようにリンク追加（ついでにやりました）

2月12日追加
・売り切れ商品には「SOLD」タグが付くようにしました。
・トップページの出品ボタンから出品ページに移動出来るよう修正しました。
・購入画面から支払画面へ遷移する条件追加（ログイン必須）
　→ログインしていなければ、ログインページに遷移

# WHY
最終発表、ポートフォリオのための微修正

# 気になること
・READMEにcommentsテーブルの記述がある。
　→実装しなければ消した方がいい？
・foreign_key: trueはDB設計で定義されているが、カラムのオプションには定義されていない
　→完成後にカラムのオプションに追加する？）
・categoriesテーブルのsize_idを使用していない