### PR TITLE
fix_SMS

### DIFF
--- a/app/views/signup/step2_2.html.haml
+++ b/app/views/signup/step2_2.html.haml
@@ -1,3 +1,7 @@
+- flash.each do |key, value|
+  = content_tag(:div, value, class: "#{key}")
+
+
 .signup-login-wrapper
 
   = render partial: "signup-header-step2"

--- a/config/initializers/twilio.rb
+++ b/config/initializers/twilio.rb
@@ -1,8 +1,9 @@
 
-require 'twilio-ruby'
-Twilio.configure do |config|
-  if Rails.env.production?
-    config.account_sid = Rails.application.credentials.twilio[:TWILIO_ACCOUNT_SID]
-    config.auth_token = Rails.application.credentials.twilio[:TWILIO_AUTH_TOKEN]
-  end
-end
+#twilioアカウント停止により一時コメントアウト
+# require 'twilio-ruby'
+# Twilio.configure do |config|
+#   # if Rails.env.production?
+#   config.account_sid = Rails.application.credentials.twilio[:TWILIO_ACCOUNT_SID]
+#   config.auth_token = Rails.application.credentials.twilio[:TWILIO_AUTH_TOKEN]
+#   # end
+# end


### PR DESCRIPTION
# WHAT
twilioアカウント停止中の一時処理として
認証番号をアラートで出すよう設定

# WHY
twilioアカウントが停止していても
ユーザーの新規登録を可能にするため。