### PR TITLE
sns_signup

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -2,12 +2,17 @@ class SignupController < ApplicationController
 
   require 'payjp'
 
+  
   before_action :save_step1_to_session, only: :step2_1
   before_action :save_step2_1_to_session, only: :sms_post
   before_action :save_step3_to_session, only: :step4
   before_action :save_step4_to_session, only: :create
   #クレジットカード登録
   before_action :card_info_to_payjp, only: :create
+
+  def index
+    session.clear
+  end
 
   def step1
     @user = User.new
@@ -76,6 +81,11 @@ class SignupController < ApplicationController
     @user.build_card_info(session[:payjp])
 
     if @user.save
+      SnsCredential.create(  #ユーザ登録と同時にこっちも登録
+        uid: session[:uid],
+        provider: session[:provider],
+        user_id: @user.id
+      )  
       session[:id] = @user.id
       redirect_to finish_signup_index_path
     else

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,7 +19,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else 
       @sns = info[:sns]
-      render template: "devise/registrations/new" 
+      session[:password_confirmation] = SecureRandom.alphanumeric(30)
+      # render template: "devise/registrations/new" 
+      if SnsCredential.find_by(uid: info[:sns][:uid], provider: info[:sns][:provider]).nil?
+        #ユーザ登録と同時にsns_credentialも登録するために
+        session[:uid] = info[:sns][:uid]
+        session[:provider] = info[:sns][:provider]
+      end
+      #登録フォームのviewにリダイレクトさせる
+      render template: "signup/step1" 
+
     end
   end
 

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -1,6 +1,6 @@
 .signup-login-wrapper
 
-  = render partial: "signup-header-step1"
+  = render partial: "signup/signup-header-step1"
 
   .signup-main
     .signup-box
@@ -21,16 +21,21 @@
                 %span.field__label__require 必須
               .field__input
                 = f.email_field :email, class: 'field__input__default',placeholder: "PC・携帯どちらでも可"
-            .field
-              .field__label
-                = f.label :パスワード, class: 'field__label__title'
-                %span.field__label__require 必須
-              .field__input
-                = f.password_field :password, class: 'field__input__default',placeholder: "PC・携帯どちらでも可"
-                %p.field__input__info ※英字と数字の両方を含めて設定してください
-              .field__checkbox
-                = f.check_box :checkbox, class: 'field__checkbox__box',:as => :boolean,checked:false
-                = f.label :パスワードを表示する, class: 'field__checkbox__label'
+            - if session[:password_confirmation].present?
+              .field
+                .field__input
+                  = f.password_field :password, type: :hidden, class: 'field__input__default',placeholder: "PC・携帯どちらでも可", value: "#{session[:password_confirmation]}"
+            - else
+              .field
+                .field__label
+                  = f.label :パスワード, class: 'field__label__title'
+                  %span.field__label__require 必須
+                .field__input
+                  = f.password_field :password, class: 'field__input__default',placeholder: "PC・携帯どちらでも可"
+                  %p.field__input__info ※英字と数字の両方を含めて設定してください
+                .field__checkbox
+                  = f.check_box :checkbox, class: 'field__checkbox__box',:as => :boolean,checked:false
+                  = f.label :パスワードを表示する, class: 'field__checkbox__label'
             .field
               %h3.field__confirm 本人確認
               %p.field__confirm-text 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
@@ -71,4 +76,4 @@
                   %a{ :href => '#' } Terms of Service
                   apply.
 
-  = render partial: "common-footer"
+  = render partial: "signup/common-footer"


### PR DESCRIPTION
# WHAT
SNSで新規登録する場合はパスワード不要にしました。
最後まで入力すると、sns_credentialsテーブルにsns認証情報が入るようにしました。

未実装部分
本来SNS連携を用いた新規登録ではお届け先情報、カード情報の入力は不要です。
現段階ではまずSNS→新規登録を実現することを目的としているため、
上記の機能は省略しました。