### PR TITLE
text-overflow

### DIFF
--- a/app/assets/stylesheets/modules/body.scss
+++ b/app/assets/stylesheets/modules/body.scss
@@ -80,15 +80,17 @@
           }
           &__text{
             height: 40px;
-            width: 152px;
+            width: 160px;
             border-top: solid 1px #000;
             background-color: #FFF;
             color: #000;
             font-weight: 100;
-            font-size: 10px;
+            font-size: 6px;
             text-align: left;
-            padding: 4px;
             position: relative;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
           }
 
           &__value{


### PR DESCRIPTION
What
text-overflowの設定
Why
商品名の長さによって、レイアウトがずれないようにするため